### PR TITLE
Crash after put app into background/foreground solution

### DIFF
--- a/CustomLayoutSample/CompositedViewController.swift
+++ b/CustomLayoutSample/CompositedViewController.swift
@@ -79,6 +79,10 @@ class CompositedViewController : UIViewController, VCConnectorIConnect {
         connector?.select(nil as VCLocalCamera?)
         connector?.select(nil as VCLocalMicrophone?)
         connector?.select(nil as VCLocalSpeaker?)
+        
+        connector?.hideView(UnsafeMutableRawPointer(&vidyoView))
+        connector?.disable()
+        
         connector = nil
         
         NotificationCenter.default.removeObserver(self)

--- a/CustomLayoutSample/CustomViewController.swift
+++ b/CustomLayoutSample/CustomViewController.swift
@@ -531,8 +531,4 @@ class CustomViewController: UIViewController, VCConnectorIConnect,
             this.dismiss(animated: true, completion: nil)
         }
     }
-    
-    deinit {
-        print("Controller deinitialized.")
-    }
 }

--- a/CustomLayoutSample/CustomViewController.swift
+++ b/CustomLayoutSample/CustomViewController.swift
@@ -115,10 +115,24 @@ class CustomViewController: UIViewController, VCConnectorIConnect,
 
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        
+        connector?.unregisterLocalCameraEventListener()
+        connector?.unregisterRemoteCameraEventListener()
+        connector?.unregisterLocalSpeakerEventListener()
+        connector?.unregisterLocalMicrophoneEventListener()
+        connector?.unregisterParticipantEventListener()
 
         connector?.select(nil as VCLocalCamera?)
         connector?.select(nil as VCLocalMicrophone?)
         connector?.select(nil as VCLocalSpeaker?)
+        
+        for var remoteView in self.remoteViewsMap.values {
+            connector?.hideView(UnsafeMutableRawPointer(&remoteView))
+        }
+        
+        connector?.hideView(UnsafeMutableRawPointer(&self.selfView))
+        connector?.disable()
+        
         connector = nil
         
         NotificationCenter.default.removeObserver(self)
@@ -380,7 +394,9 @@ class CustomViewController: UIViewController, VCConnectorIConnect,
                 return
             }
             
-            let remoteView = this.remoteViewsMap.removeValue(forKey: participant.getId())
+            var remoteView = this.remoteViewsMap.removeValue(forKey: participant.getId())
+            this.connector?.hideView(UnsafeMutableRawPointer(&remoteView))
+
             for view in (remoteView?.subviews)!{
                 view.removeFromSuperview()
             }
@@ -514,5 +530,9 @@ class CustomViewController: UIViewController, VCConnectorIConnect,
             
             this.dismiss(animated: true, completion: nil)
         }
+    }
+    
+    deinit {
+        print("Controller deinitialized.")
     }
 }


### PR DESCRIPTION
- disable() API usage;
- Hide views upon destructing connector instance in order to avoid background/foreground crash on the next conference.